### PR TITLE
Small update to cabal file to install on ghc 7.x

### DIFF
--- a/lenses.cabal
+++ b/lenses.cabal
@@ -1,5 +1,5 @@
 Name:                lenses
-Version:             0.1.4
+Version:             0.1.5
 Author:              Job Vranish
 Maintainer:          jvranish@gmail.com
 Homepage:            http://github.com/jvranish/Lenses/tree/master
@@ -26,7 +26,7 @@ library
     If impl(ghc)
       If impl(ghc >= 6.12)
         Hs-Source-Dirs: src-24
-        Build-Depends:  template-haskell >=2.4 && <2.6
+        Build-Depends:  template-haskell >=2.4 && <2.8
       Else
         Hs-Source-Dirs: src-23
         Build-Depends:  template-haskell >=2.2 && <2.4


### PR DESCRIPTION
I am not sure this is completely valid, but it works fine on my local install of ghc 7.4.1.

lenses-0.14 will not install because it depends on template-haskell <2.6, and 2.5.0.0 no longer builds on my version of ghc.  I'm simply running the packaged ghc from Ubuntu 12.04.
